### PR TITLE
chore: 非推奨なVSCode拡張機能の削除

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,6 @@
     "esbenp.prettier-vscode",
     "yoavbls.pretty-ts-errors",
     "stylelint.vscode-stylelint",
-    "vue.volar",
-    "vue.vscode-typescript-vue-plugin"
+    "vue.volar"
   ]
 }


### PR DESCRIPTION
vue.vscode-typescript-vue-plugin を削除