### PR TITLE
回答期限の時刻入力を直接入力可能にする

### DIFF
--- a/assets/style/global.css
+++ b/assets/style/global.css
@@ -216,6 +216,37 @@
   border-radius: var(--p-border-radius-md);
 }
 
+.p-datepicker-panel {
+  padding: 12px;
+  display: flex;
+  gap: 8px;
+  justify-content: space-evenly;
+  flex-wrap: wrap;
+}
+
+.p-datepicker-panel .p-datepicker-prev-button,
+.p-datepicker-panel .p-datepicker-next-button {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+}
+
+.p-datepicker-panel .p-datepicker-prev-button:hover,
+.p-datepicker-panel .p-datepicker-next-button:hover {
+  background-color: var(--p-surface-100);
+  border: none;
+}
+
+.p-datepicker-weekday-cell {
+  padding: 0;
+}
+
+.p-datepicker-day-cell {
+  padding: 2px;
+}
+
 .questionnaire-form-container
   .smooth-dnd-container.vertical
   > .smooth-dnd-draggable-wrapper {

--- a/components/questionnaire-form/response-due-date-time-input.vue
+++ b/components/questionnaire-form/response-due-date-time-input.vue
@@ -19,22 +19,22 @@ type DueDatePreset = DueDatePresetItem['value'];
 const getMatchingDueDatePreset = (date: Date): DueDatePreset | null => {
   const dateIso = date.toISOString();
   const dateKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
- 
+
   const matchedPreset = dueDatePresets.find((preset) => {
     const presetDate = addDays(today, preset.days);
- 
+
     if (presetDate.toISOString() === dateIso) return true;
- 
+
     const presetDateKey = `${presetDate.getFullYear()}-${presetDate.getMonth()}-${presetDate.getDate()}`;
     return presetDateKey === dateKey;
   });
- 
+
   return matchedPreset?.value ?? null;
 };
 
 const isResponseDueDateTimeInvalidForTargets = computed(() => {
   if (state.value.response_due_date_time !== undefined) return false;
- 
+
   return (
     state.value.target.users.length > 0 || state.value.target.groups.length > 0
   );
@@ -45,7 +45,7 @@ const hasTargets = computed(
 );
 const isResponseDueDateTimeInvalidForDate = computed(() => {
   if (state.value.response_due_date_time === undefined) return false;
- 
+
   return new Date(state.value.response_due_date_time) < new Date();
 });
 

--- a/components/questionnaire-form/response-due-date-time-input.vue
+++ b/components/questionnaire-form/response-due-date-time-input.vue
@@ -19,22 +19,22 @@ type DueDatePreset = DueDatePresetItem['value'];
 const getMatchingDueDatePreset = (date: Date): DueDatePreset | null => {
   const dateIso = date.toISOString();
   const dateKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-
+ 
   const matchedPreset = dueDatePresets.find((preset) => {
     const presetDate = addDays(today, preset.days);
-
+ 
     if (presetDate.toISOString() === dateIso) return true;
-
+ 
     const presetDateKey = `${presetDate.getFullYear()}-${presetDate.getMonth()}-${presetDate.getDate()}`;
     return presetDateKey === dateKey;
   });
-
+ 
   return matchedPreset?.value ?? null;
 };
 
 const isResponseDueDateTimeInvalidForTargets = computed(() => {
   if (state.value.response_due_date_time !== undefined) return false;
-
+ 
   return (
     state.value.target.users.length > 0 || state.value.target.groups.length > 0
   );
@@ -45,7 +45,7 @@ const hasTargets = computed(
 );
 const isResponseDueDateTimeInvalidForDate = computed(() => {
   if (state.value.response_due_date_time === undefined) return false;
-
+ 
   return new Date(state.value.response_due_date_time) < new Date();
 });
 
@@ -91,10 +91,10 @@ watch(
       responseDueDateTimeInput.value = getDefaultDueDate();
       return;
     }
-
+ 
     const nextDueDate = new Date(value);
     if (Number.isNaN(nextDueDate.getTime())) return;
-
+ 
     useCustomDueTime.value = true;
     responseDueDateTimeInput.value = nextDueDate;
   },
@@ -124,29 +124,29 @@ watch(hasTargets, (value) => {
 });
 
 const responseDueDateNoDueId = useId();
+
+const dueHour = computed({
+  get: () => responseDueDateTimeInput.value.getHours(),
+  set: (h: number | null) => {
+    if (h === null) return;
+    const newDate = new Date(responseDueDateTimeInput.value);
+    newDate.setHours(h, newDate.getMinutes(), 0, 0);
+    responseDueDateTimeInput.value = newDate;
+  },
+});
+
+const dueMinute = computed({
+  get: () => responseDueDateTimeInput.value.getMinutes(),
+  set: (m: number | null) => {
+    if (m === null) return;
+    const newDate = new Date(responseDueDateTimeInput.value);
+    newDate.setHours(newDate.getHours(), m, 0, 0);
+    responseDueDateTimeInput.value = newDate;
+  },
+});
 </script>
 
 <template>
-  <div class="response-due-date-time-input">
-    <div class="response-due-date-time-input-title">
-      <p class="form-label">回答期限</p>
-      <div class="due-date-mode-options">
-        <label class="due-date-mode-option">
-          <span>設定する</span>
-
-          <ToggleSwitch
-            v-model="useCustomDueTime"
-            :input-id="responseDueDateNoDueId"
-            binary
-          />
-        </label>
-      </div>
-    </div>
-
-    <DatePicker
-      v-if="useCustomDueTime"
-      v-model="responseDueDateTimeInput"
-      :min-date="minSelectableDueDate"
       :class="{
         'p-invalid': isResponseDueDateTimeInvalidForDate,
       }"
@@ -173,36 +173,37 @@ const responseDueDateNoDueId = useId();
     </small>
 
     <small v-if="isResponseDueDateTimeInvalidForDate" class="invalid-message">
-      <Icon name="mdi:alert-circle" size="20px" />
-      過去の日時を設定することはできません
-    </small>
-  </div>
-</template>
-
-<style lang="scss" scoped>
-.response-due-date-time-input {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.response-due-date-time-input-title {
-  display: flex;
-  flex-direction: row;
-  gap: 20px;
-  align-items: center;
-}
-
-.form-label {
-  font-weight: bold;
-}
-
-.due-date-mode-options {
-  display: flex;
-  gap: 14px;
-  align-items: center;
-}
-
+      hour-format="24"
+      show-icon
+      icon-display="input"
+    ></DatePicker>
+      :pt="{ timePicker: { style: 'display: none' } }"
+    >
+      <template #footer>
+        <div class="custom-time-picker">
+          <InputNumber
+            v-model="dueHour"
+            :min="0"
+            :max="23"
+            :step="1"
+            show-buttons
+            button-layout="vertical"
+          />
+          <span class="time-colon">:</span>
+          <InputNumber
+            v-model="dueMinute"
+            :min="0"
+            :max="59"
+            :step="1"
+            show-buttons
+            button-layout="vertical"
+          />
+        </div>
+      </template>
+    </DatePicker>
+    <ChipSelectRow
+      v-if="useCustomDueTime"
+      class="due-date-presets"
 .due-date-mode-option {
   display: flex;
   gap: 6px;
@@ -229,3 +230,30 @@ const responseDueDateNoDueId = useId();
   color: var(--p-red-500);
 }
 </style>
+ 
+  font-weight: 500;
+}
+
+.custom-time-picker {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  padding-block: 8px;
+ 
+  :deep(.p-inputnumber-input) {
+    width: 3rem;
+    text-align: center;
+    padding-inline: 0.25rem;
+  }
+}
+
+.time-colon {
+  font-size: 1.1rem;
+  font-weight: bold;
+  line-height: 1;
+}
+
+.due-date-presets {
+  margin-top: 2px;
+}

--- a/components/questionnaire-form/response-due-date-time-input.vue
+++ b/components/questionnaire-form/response-due-date-time-input.vue
@@ -123,8 +123,6 @@ watch(hasTargets, (value) => {
   useCustomDueTime.value = true;
 });
 
-const responseDueDateNoDueId = useId();
-
 const dueHour = computed({
   get: () => responseDueDateTimeInput.value.getHours(),
   set: (h: number | null) => {
@@ -154,11 +152,7 @@ const dueMinute = computed({
         <label class="due-date-mode-option">
           <span>設定する</span>
 
-          <ToggleSwitch
-            v-model="useCustomDueTime"
-            :input-id="responseDueDateNoDueId"
-            binary
-          />
+          <ToggleSwitch v-model="useCustomDueTime" binary />
         </label>
       </div>
     </div>
@@ -272,6 +266,7 @@ const dueMinute = computed({
     width: 3rem;
     text-align: center;
     padding-inline: 0.25rem;
+    z-index: 1;
   }
 }
 

--- a/components/questionnaire-form/response-due-date-time-input.vue
+++ b/components/questionnaire-form/response-due-date-time-input.vue
@@ -91,10 +91,10 @@ watch(
       responseDueDateTimeInput.value = getDefaultDueDate();
       return;
     }
- 
+
     const nextDueDate = new Date(value);
     if (Number.isNaN(nextDueDate.getTime())) return;
- 
+
     useCustomDueTime.value = true;
     responseDueDateTimeInput.value = nextDueDate;
   },
@@ -147,6 +147,26 @@ const dueMinute = computed({
 </script>
 
 <template>
+  <div class="response-due-date-time-input">
+    <div class="response-due-date-time-input-title">
+      <p class="form-label">回答期限</p>
+      <div class="due-date-mode-options">
+        <label class="due-date-mode-option">
+          <span>設定する</span>
+
+          <ToggleSwitch
+            v-model="useCustomDueTime"
+            :input-id="responseDueDateNoDueId"
+            binary
+          />
+        </label>
+      </div>
+    </div>
+
+    <DatePicker
+      v-if="useCustomDueTime"
+      v-model="responseDueDateTimeInput"
+      :min-date="minSelectableDueDate"
       :class="{
         'p-invalid': isResponseDueDateTimeInvalidForDate,
       }"
@@ -156,27 +176,6 @@ const dueMinute = computed({
       hour-format="24"
       show-icon
       icon-display="input"
-    ></DatePicker>
-    <ChipSelectRow
-      v-if="useCustomDueTime"
-      class="due-date-presets"
-      :items="dueDatePresetChipItems"
-      :selected-key="selectedDueDatePreset"
-      @select="handleSelectDueDatePresetByValue"
-    />
-    <small
-      v-if="isResponseDueDateTimeInvalidForTargets"
-      class="invalid-message"
-    >
-      <Icon name="mdi:alert-circle" size="20px" />
-      <span>対象者を設定する場合「期限なし」にすることはできません</span>
-    </small>
-
-    <small v-if="isResponseDueDateTimeInvalidForDate" class="invalid-message">
-      hour-format="24"
-      show-icon
-      icon-display="input"
-    ></DatePicker>
       :pt="{ timePicker: { style: 'display: none' } }"
     >
       <template #footer>
@@ -204,6 +203,49 @@ const dueMinute = computed({
     <ChipSelectRow
       v-if="useCustomDueTime"
       class="due-date-presets"
+      :items="dueDatePresetChipItems"
+      :selected-key="selectedDueDatePreset"
+      @select="handleSelectDueDatePresetByValue"
+    />
+    <small
+      v-if="isResponseDueDateTimeInvalidForTargets"
+      class="invalid-message"
+    >
+      <Icon name="mdi:alert-circle" size="20px" />
+      <span>対象者を設定する場合「期限なし」にすることはできません</span>
+    </small>
+
+    <small v-if="isResponseDueDateTimeInvalidForDate" class="invalid-message">
+      <Icon name="mdi:alert-circle" size="20px" />
+      過去の日時を設定することはできません
+    </small>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.response-due-date-time-input {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.response-due-date-time-input-title {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  align-items: center;
+}
+
+.form-label {
+  font-weight: bold;
+}
+
+.due-date-mode-options {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+
 .due-date-mode-option {
   display: flex;
   gap: 6px;
@@ -219,28 +261,13 @@ const dueMinute = computed({
   font-weight: 500;
 }
 
-.due-date-presets {
-  margin-top: 2px;
-}
-
-.invalid-message {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--p-red-500);
-}
-</style>
- 
-  font-weight: 500;
-}
-
 .custom-time-picker {
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 4px;
   padding-block: 8px;
- 
+
   :deep(.p-inputnumber-input) {
     width: 3rem;
     text-align: center;
@@ -257,3 +284,11 @@ const dueMinute = computed({
 .due-date-presets {
   margin-top: 2px;
 }
+
+.invalid-message {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--p-red-500);
+}
+</style>


### PR DESCRIPTION
## 概要

アンケート作成時の回答期限設定において、時刻の時・分を直接キーボード入力できるようにしました。

## 変更内容

PrimeVue の `DatePicker` に `show-time` で表示される時刻スピナーは内部的に `<span>` 要素で描画されており、上下ボタンでしか値を変更できませんでした。

- PT（pass-through）で既存の時刻スピナーを非表示にする
- `#footer` スロットに `InputNumber` コンポーネント（時: 0〜23、分: 0〜59）を配置する
- 上下ボタンによる操作は引き続き可能

## Before / After

**Before:** 時刻を変更するには上下ボタンを1ずつクリックする必要があった（例: 1分 → 30分に変えるには29回クリック）

**After:** 数値フィールドを直接クリックしてキーボードで入力できる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 応答期限の時間選択が改善され、時間と分を個別の入力で直感的かつ正確に設定できるようになりました。
* **Style**
  * 日付ピッカーのパネルとナビゲーションのレイアウト・間隔を調整し、操作性と見た目を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->