### PR TITLE
管理中フィルタで下書きも表示する

### DIFF
--- a/components/explorer/explorer-advanced-filter-grid.vue
+++ b/components/explorer/explorer-advanced-filter-grid.vue
@@ -78,7 +78,7 @@ const draftScopeOptions = [
 
 const administrationScopeOptions = [
   { label: 'フィルタなし', value: 'all' },
-  { label: '管理中 (公開済み)', value: 'published' },
+  { label: '管理中 (全て)', value: 'administered' },
   { label: '管理中 (下書き)', value: 'draft' },
 ] satisfies SelectOption<AdministrationScope>[];
 </script>

--- a/components/explorer/filter-domain.test.ts
+++ b/components/explorer/filter-domain.test.ts
@@ -31,7 +31,7 @@ describe('filter-domain core state', () => {
       targetScope: 'targetingMe',
       responseScope: 'answered',
       draftScope: 'all',
-      administrationScope: 'published',
+      administrationScope: 'administered',
     };
 
     expect(toSortedArray(buildFilterSetFromAdvancedState(state))).toEqual(['administered', 'answered', 'targeting']);

--- a/components/explorer/filter-domain.ts
+++ b/components/explorer/filter-domain.ts
@@ -89,7 +89,7 @@ const resolveAdministrationScope = (filters: Set<FilterKey>): AdministrationScop
   }
 
   if (filters.has('administered')) {
-    return 'published';
+    return 'administered';
   }
 
   return 'all';
@@ -133,7 +133,7 @@ export const buildFilterSetFromAdvancedState = (state: ExplorerAdvancedFilterSta
     next.add('draft');
   }
 
-  if (state.administrationScope === 'published') {
+  if (state.administrationScope === 'administered') {
     next.add('administered');
   }
 

--- a/components/explorer/filter-payload.test.ts
+++ b/components/explorer/filter-payload.test.ts
@@ -37,4 +37,24 @@ describe('filter-payload query builder', () => {
     expect(withDue.notOverDue).toBe(true);
     expect(withoutDue.notOverDue).toBeUndefined();
   });
+
+  it('includes both published and draft questionnaires for the administered filter', () => {
+    const administered = buildListQuery({
+      searchQuery: '',
+      filters: new Set<FilterKey>(['administered']),
+      sortCategory: 'createdAt',
+      sortDirection: 'desc',
+    });
+
+    const draft = buildListQuery({
+      searchQuery: '',
+      filters: new Set<FilterKey>(['administered', 'unpublished']),
+      sortCategory: 'createdAt',
+      sortDirection: 'desc',
+    });
+
+    expect(administered.onlyAdministratedByMe).toBe(true);
+    expect(administered.isDraft).toBeUndefined();
+    expect(draft.isDraft).toBe(true);
+  });
 });

--- a/components/explorer/filter-payload.ts
+++ b/components/explorer/filter-payload.ts
@@ -29,7 +29,7 @@ export const buildListQuery = ({
     isDraft:
       administrationScope === 'draft'
         ? true
-        : administrationScope === 'published' || responseScope === 'unanswered'
+        : responseScope === 'unanswered'
           ? false
           : undefined,
   };

--- a/components/explorer/filter-types.ts
+++ b/components/explorer/filter-types.ts
@@ -12,7 +12,7 @@ export type ResponseScope = 'all' | 'answered' | 'unanswered';
 
 export type DraftScope = 'all' | 'hasMyDraft';
 
-export type AdministrationScope = 'all' | 'published' | 'draft';
+export type AdministrationScope = 'all' | 'administered' | 'draft';
 
 export type ExplorerAdvancedFilterState = {
   targetScope: TargetScope;


### PR DESCRIPTION
## 変更内容
管理フィルタの「管理中 (公開済み)」を「管理中 (全て)」に変更し、公開済み・下書きの両方を表示できるようにしました。

## 背景
管理中フィルタで公開済みだけが対象になっており、下書きを含めて確認できませんでした。

## 確認
- `npm test -- --run components/explorer/filter-domain.test.ts components/explorer/filter-payload.test.ts`
- `npm run lint`（既存警告のみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 高度な検索フィルターに「管理中（全て）」を追加しました。
  - 自分が管理する公開済み・未公開の項目をまとめて検索できます。
- **改善**
  - 管理範囲フィルターの選択肢を見直し、従来の「管理中（公開済み）」を「管理中（全て）」に変更しました。
  - 管理範囲と公開状態を組み合わせた検索条件が、より正確に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->